### PR TITLE
Improve robustness

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ endif()
 
 add_executable(unittests
   tests/tests.cc
+  tests/test-ill-formed-paths.cc
   src/toppra.cc
 )
 add_test(unittests unittests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ compute_project_args(PROJECT_ARGS LANGUAGES CXX)
 project(${PROJECT_NAME} ${PROJECT_ARGS})
 
 add_project_dependency(hpp-core REQUIRED)
+add_project_dependency(hpp-manipulation REQUIRED)
 add_project_dependency(toppra REQUIRED)
 
 include(${HPP_CORE_CMAKE_PLUGIN})
@@ -72,10 +73,11 @@ endif()
 add_executable(unittests
   tests/tests.cc
   tests/test-ill-formed-paths.cc
+  tests/test-path-serialization.cc
   src/toppra.cc
 )
 add_test(unittests unittests)
-target_link_libraries(unittests hpp-core::hpp-core toppra::toppra Catch2::Catch2WithMain)
+target_link_libraries(unittests hpp-core::hpp-core hpp-manipulation::hpp-manipulation toppra::toppra Catch2::Catch2WithMain)
 
 project_install_component(toppra)
 install(FILES src/toppra.hh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,50 @@ hpp_add_plugin(toppra
   SOURCES src/toppra
   LINK_DEPENDENCIES PUBLIC hpp-core::hpp-core toppra::toppra)
 
+if(${CMAKE_VERSION} VERSION_GREATER 3.11.4)
+  Include(FetchContent)
+
+  FetchContent_Declare(
+    Catch2
+    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+    GIT_TAG        v3.0.1)
+
+  FetchContent_MakeAvailable(Catch2)
+else()
+  include(ExternalProject)
+  find_package(Git REQUIRED)
+
+  ExternalProject_Add(
+          catch2
+          PREFIX ${CMAKE_BINARY_DIR}/catch2
+          GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+          GIT_TAG v3.0.1
+          GIT_SHALLOW TRUE
+          TIMEOUT 10
+          UPDATE_COMMAND ${GIT_EXECUTABLE} pull
+          CONFIGURE_COMMAND ""
+          BUILD_COMMAND ""
+          INSTALL_COMMAND ""
+          LOG_DOWNLOAD ON
+          )
+
+  ExternalProject_Get_Property(catch2 SOURCE_DIR)
+  set(CATCH_INCLUDE_DIR ${SOURCE_DIR}/single_include)
+  message("CATCH_INCLUDE_DIR: ${CATCH_INCLUDE_DIR}")
+  add_library(Catch2 INTERFACE)
+  target_include_directories(Catch2 INTERFACE ${CATCH_INCLUDE_DIR})
+
+  add_library(Catch2::Catch2 ALIAS Catch2)
+endif()
+
+
+add_executable(unittests
+  tests/tests.cc
+  src/toppra.cc
+)
+add_test(unittests unittests)
+target_link_libraries(unittests hpp-core::hpp-core toppra::toppra Catch2::Catch2WithMain)
+
 project_install_component(toppra)
 install(FILES src/toppra.hh
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/hpp/core/path-optimization/)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ else()
   add_library(Catch2::Catch2 ALIAS Catch2)
 endif()
 
+add_subdirectory(python)
 
 add_executable(unittests
   tests/tests.cc

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,0 +1,13 @@
+find_package(pybind11 REQUIRED)
+
+message("Found ${PYTHON_INCLUDE_DIR} ${PYTHON_EXECUTABLE}")
+
+pybind11_add_module(hpp_toppra_cpp
+  path.cc
+)
+target_link_libraries(hpp_toppra_cpp
+  PUBLIC
+  hpp-core::hpp-core
+  hpp-manipulation::hpp-manipulation
+  toppra::toppra
+)

--- a/python/path.cc
+++ b/python/path.cc
@@ -1,0 +1,127 @@
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+
+#include<sstream>
+#include<hpp/pinocchio/device.hh>
+#include<hpp/pinocchio/urdf/util.hh>
+#include<hpp/core/path.hh>
+#include<hpp/core/path-vector.hh>
+#include<hpp/manipulation/device.hh>
+
+#include <toppra/geometric_path.hpp>
+
+#include "../src/serialization.hh"
+
+namespace py = pybind11;
+
+namespace hpp {
+namespace pinocchio {
+void expose(py::module &m) {
+  py::class_<Device, DevicePtr_t>(m, "Device")
+    .def_static("create", &Device::create)
+    ;
+
+  {
+    py::module sm = m.def_submodule("urdf");
+    sm.def("loadModel", [](
+          const DevicePtr_t& robot, const FrameIndex& baseFrame,
+          const std::string& prefix, const std::string& rootType,
+          const std::string& urdfPath, const std::string& srdfPath
+          // , const SE3& bMr = SE3::Identity()
+          ) {
+        urdf::loadModel(robot, baseFrame, prefix, rootType, urdfPath, srdfPath, SE3::Identity());
+      });
+  }
+}
+}
+namespace core {
+
+class TOPPRAPathWrapper : public toppra::GeometricPath {
+ public:
+  TOPPRAPathWrapper(PathPtr_t path)
+      : toppra::GeometricPath((int)path->outputSize(),
+                              (int)path->outputDerivativeSize()),
+        path_(path) {}
+
+  toppra::Vector eval_single(toppra::value_type time, int order) const {
+    bool success;
+    toppra::Vector res;
+    if (order == 0) {
+      res = path_->eval(time, success);
+      assert(success);
+    } else {
+      res.resize(dof());
+      path_->derivative(res, time, order);
+    }
+    return res;
+  }
+
+  toppra::Bound pathInterval() const {
+    const interval_t& tr = path_->timeRange();
+    return (toppra::Bound() << tr.first, tr.second).finished();
+  }
+
+ private:
+  PathPtr_t path_;
+};
+
+PathPtr_t readBinPath(DevicePtr_t device, std::string filename) {
+  PathPtr_t path;
+  parser::serializePath<serialization::binary_iarchive>(device, path, filename);
+  return path;
+}
+
+void expose(py::module &m) {
+  py::class_<Path, PathPtr_t>(m, "Path")
+    .def("eval", [](const PathPtr_t& path, value_type time) {
+        bool success;
+        Configuration_t q = path->eval(time, success);
+        return py::make_tuple(q, success);
+    })
+    .def("derivative", [](const PathPtr_t& path, value_type time, size_type order) {
+        vector_t der (path->outputDerivativeSize());
+        path->derivative(der, time, order);
+        return der;
+    })
+    .def("velocityBound", [](const PathPtr_t& path, value_type t0, value_type t1) {
+        vector_t res (path->outputDerivativeSize());
+        path->velocityBound(res, t0, t1);
+        return res;
+    })
+    .def_property_readonly("timeRange", [](Path const& p) { return p.timeRange(); })
+    .def("length", &Path::length)
+    .def("str", [](const Path& p) {
+        std::ostringstream oss;
+        oss << p;
+        return oss.str();
+      })
+    ;
+  py::class_<PathVector, PathVectorPtr_t, Path>(m, "PathVector")
+    .def("numberPaths", &PathVector::numberPaths)
+    .def("pathAtRank", &PathVector::pathAtRank)
+  ;
+  py::class_<TOPPRAPathWrapper,
+    std::shared_ptr<TOPPRAPathWrapper>,
+    toppra::GeometricPath>(m, "TOPPRAPathWrapper")
+    .def(py::init<PathPtr_t>())
+  ;
+
+  m.def("readBinPath", &readBinPath);
+}
+}
+}
+
+PYBIND11_MODULE(hpp_toppra_cpp, m)
+{
+  py::module_::import("toppra.cpp");
+  {
+    py::module sm = m.def_submodule("pinocchio");
+    hpp::pinocchio::expose(sm);
+  }
+  {
+    py::module sm = m.def_submodule("core");
+    hpp::core::expose(sm);
+  }
+
+  hpp::manipulation::Device::create("fake");
+}

--- a/src/piecewise-polynomial.hh
+++ b/src/piecewise-polynomial.hh
@@ -1,0 +1,125 @@
+#include <hpp/core/time-parameterization/piecewise-polynomial.hh>
+
+namespace hpp {
+namespace core {
+namespace timeParameterization {
+
+// TODO This can be removed when the changes in hpp-core
+// related to PiecewisePolynomial::polynomialStartAtZero
+// is merged.
+template <int _Order>
+class HPP_CORE_DLLAPI ShiftedPiecewisePolynomial : public TimeParameterization {
+ public:
+  enum {
+    Order = _Order,
+    NbCoeffs = Order + 1,
+  };
+
+  typedef Eigen::Matrix<value_type, NbCoeffs, Eigen::Dynamic, Eigen::ColMajor>
+      ParameterMatrix_t;
+  typedef Eigen::Matrix<value_type, Eigen::Dynamic, 1> Vector_t;
+
+  /** Construct piecewise polynomials of order k and defined by N polynomial.
+   * \param parameters Matrix of polynomials coefficients (size k x N).
+   * \param breakpoints Domain of the piecewise polynomial, defined by N+1
+   * breakpoints defining the half-open intervals of each polynomial.
+   */
+  ShiftedPiecewisePolynomial(const ParameterMatrix_t& parameters,
+                             const Vector_t& breakpoints)
+      : parameters_(parameters), breakpoints_(breakpoints) {
+    assert(breakpoints_.size() == parameters_.cols() + 1);
+    assert(parameters_.rows() == NbCoeffs);
+
+    for (size_type j = 0; j < parameters_.cols(); ++j) {
+      if (j > 0) {
+        assert(breakpoints_[j] > breakpoints_[j - 1]);
+      }
+      for (size_type i = 0; i < parameters_.rows(); ++i) {
+        assert(parameters_(i, j) < std::numeric_limits<value_type>::infinity());
+        assert(parameters_(i, j) >
+               -std::numeric_limits<value_type>::infinity());
+      }
+    }
+  }
+
+  const ParameterMatrix_t& parameters() const { return parameters_; }
+
+  TimeParameterizationPtr_t copy() const {
+    return TimeParameterizationPtr_t(new ShiftedPiecewisePolynomial(*this));
+  }
+
+  /// Computes \f$ \sum_{i=0}^n a_i t^i \f$
+  value_type value(const value_type& t) const { return val(t); }
+
+  /// Computes \f$ \sum_{i=1}^n i a_i t^{i-1} \f$
+  value_type derivative(const value_type& t, const size_type& order) const {
+    return Jac(t, order);
+  }
+
+ private:
+  value_type val(const value_type& t) const {
+    value_type tl = t;
+    const size_t seg_index = findPolynomialIndex(tl);
+    const auto& poly_coeffs = parameters_.col(seg_index);
+    value_type tn = 1;
+    value_type res = poly_coeffs[0];
+    for (size_type i = 1; i < poly_coeffs.size(); ++i) {
+      tn *= tl;
+      res += poly_coeffs[i] * tn;
+    }
+    assert(res == res);
+    return res;
+  }
+
+  value_type Jac(const value_type& t) const { return Jac(t, 1); }
+
+  value_type Jac(const value_type& t, const size_type& order) const {
+    if (order >= parameters_.rows()) return 0;
+    const size_type MaxOrder = 10;
+    if (parameters_.rows() > MaxOrder)
+      throw std::invalid_argument(
+          "Cannot compute the derivative of order greater than 10.");
+    typedef path::binomials<MaxOrder> Binomials_t;
+    const Binomials_t::Factorials_t& factors = Binomials_t::factorials();
+
+    value_type tl = t;
+    const size_t seg_index = findPolynomialIndex(tl);
+    const auto& poly_coeffs = parameters_.col(seg_index);
+
+    value_type res = 0;
+    value_type tn = 1;
+    for (size_type i = order; i < poly_coeffs.size(); ++i) {
+      res += value_type(factors[i] / factors[i - order]) * poly_coeffs[i] * tn;
+      tn *= tl;
+    }
+    return res;
+  }
+
+  size_t findPolynomialIndex(value_type& t) const {
+    size_t seg_index = std::numeric_limits<size_t>::max();
+    for (int i = 0; i < parameters_.cols(); ++i) {
+      if (breakpoints_[i] <= t && t <= breakpoints_[i + 1]) {
+        seg_index = i;
+        break;
+      }
+    }
+    if (seg_index == std::numeric_limits<size_t>::max()) {
+      std::ostringstream oss;
+      oss << "Position " << t << " is outside of range [ " << breakpoints_[0]
+          << ", " << breakpoints_[breakpoints_.size() - 1] << ']';
+      throw std::runtime_error(oss.str());
+    }
+    t -= breakpoints_[seg_index];
+    return seg_index;
+  }
+
+  /// Parameters of the polynomials are stored in a matrix
+  ///   number of rows = degree of polynomial + 1
+  ///   number of columns = number of polynomials N
+  ParameterMatrix_t parameters_;
+  Vector_t breakpoints_;  // size N + 1
+};                        // class ShiftedPiecewisePolynomial
+
+}  // namespace timeParameterization
+}  // namespace core
+}  // namespace hpp

--- a/src/serialization.hh
+++ b/src/serialization.hh
@@ -1,0 +1,30 @@
+#ifndef HPP_TOPPRA_SERIALIZATION_HH
+#define HPP_TOPPRA_SERIALIZATION_HH
+
+#include <fstream>
+#include <hpp/core/path.hh>
+#include <hpp/pinocchio/serialization.hh>
+
+namespace hpp {
+namespace core {
+namespace parser {
+template <class Archive>
+void serializePath(
+    DevicePtr_t& device,
+    PathPtr_t& path,
+    const std::string& filename)
+{
+  typename std::conditional<Archive::is_saving::value, std::ofstream,
+                            std::ifstream>::type fs(filename);
+  Archive ar(fs);
+  if (device)
+    ar.insert(device->name(), device.get());
+  ar.initialize();
+  //ar& hpp::serialization::make_nvp("device", device);
+  ar& hpp::serialization::make_nvp("path", path);
+}
+/// \}
+}  // namespace parser
+}  // namespace core
+}  // namespace hpp
+#endif  // HPP_CORE_PARSER_ROADMAP_HH

--- a/src/toppra.cc
+++ b/src/toppra.cc
@@ -345,6 +345,7 @@ PathVectorPtr_t TOPPRA::optimize(const PathVectorPtr_t& path) {
     res->appendPath(paths[i]);
   }
 
+  lastTimeParameterization_ = global;
   return res;
 }
 

--- a/src/toppra.cc
+++ b/src/toppra.cc
@@ -260,13 +260,27 @@ toppra::Vector evenlyTimeSpacedGridpoints(
 }
 
 void TOPPRA::inputSerialization(PathPtr_t path) const {
-  const std::string filename =
+  std::string filename =
       problem()->getParameter(PARAM_HEAD "inputSerialization").stringValue();
   if (filename.size() == 0)
     return;
 
+  bool textFormat = (filename.size() > 4
+                     && filename.substr(filename.size() - 4) == ".txt");
+
+  // Find a non existent filename
+  const std::string basename (filename);
+  int i = 1;
+  while (std::ifstream(filename).is_open()) {
+    std::ostringstream oss;
+    oss << basename << i;
+    filename = oss.str();
+    i += 1;
+  }
+  std::cout << "saving to " << filename << '\n';
+
   DevicePtr_t device(problem()->robot());
-  if (filename.substr(filename.size() - 4) == ".txt")
+  if (textFormat)
     parser::serializePath<serialization::text_oarchive>(device, path, filename);
   else
     parser::serializePath<serialization::binary_oarchive>(device, path, filename);

--- a/src/toppra.cc
+++ b/src/toppra.cc
@@ -242,6 +242,8 @@ PathVectorPtr_t TOPPRA::optimize(const PathVectorPtr_t& path) {
     torqueConstraint->upperBounds(effortScale * torqueConstraint->upperBounds());
     v.push_back(torqueConstraint);
   }
+  for (auto& c : v)
+    c->discretizationType(toppra::Interpolation);
 
   PathVectorPtr_t flatten_path =
       PathVector::create(path->outputSize(), path->outputDerivativeSize());

--- a/src/toppra.hh
+++ b/src/toppra.hh
@@ -47,6 +47,10 @@ class TOPPRA : public PathOptimizer {
      ConstantAcceleration,
      Hermite,
    };
+   enum GridpointMethod {
+     EvenlyTimeSpaced,
+     EvenlyParamSpaced,
+   };
 
   static TOPPRAPtr_t create(const ProblemConstPtr_t &p) {
     return TOPPRAPtr_t(new TOPPRA(p));
@@ -65,6 +69,7 @@ class TOPPRA : public PathOptimizer {
  private:
   toppra::LinearConstraintPtrs constraints();
   InterpolationMethod interpolationMethod() const;
+  GridpointMethod gridpointMethod() const;
 };  // class TOPPRA
 
 }  // namespace pathOptimization

--- a/src/toppra.hh
+++ b/src/toppra.hh
@@ -43,6 +43,11 @@ typedef shared_ptr<TOPPRA> TOPPRAPtr_t;
 
 class TOPPRA : public PathOptimizer {
  public:
+   enum InterpolationMethod {
+     ConstantAcceleration,
+     Hermite,
+   };
+
   static TOPPRAPtr_t create(const ProblemConstPtr_t &p) {
     return TOPPRAPtr_t(new TOPPRA(p));
   }
@@ -59,6 +64,7 @@ class TOPPRA : public PathOptimizer {
 
  private:
   toppra::LinearConstraintPtrs constraints();
+  InterpolationMethod interpolationMethod() const;
 };  // class TOPPRA
 
 }  // namespace pathOptimization

--- a/src/toppra.hh
+++ b/src/toppra.hh
@@ -67,6 +67,7 @@ class TOPPRA : public PathOptimizer {
   using PathOptimizer::PathOptimizer;
 
  private:
+  void inputSerialization(PathPtr_t path) const;
   toppra::LinearConstraintPtrs constraints();
   InterpolationMethod interpolationMethod() const;
   GridpointMethod gridpointMethod() const;

--- a/src/toppra.hh
+++ b/src/toppra.hh
@@ -32,6 +32,8 @@
 
 #include <hpp/core/path-optimizer.hh>
 
+#include <toppra/toppra.hpp>
+
 namespace hpp {
 namespace core {
 namespace pathOptimization {
@@ -54,6 +56,9 @@ class TOPPRA : public PathOptimizer {
 
  protected:
   using PathOptimizer::PathOptimizer;
+
+ private:
+  toppra::LinearConstraintPtrs constraints();
 };  // class TOPPRA
 
 }  // namespace pathOptimization

--- a/src/toppra.hh
+++ b/src/toppra.hh
@@ -47,6 +47,11 @@ class TOPPRA : public PathOptimizer {
 
   PathVectorPtr_t optimize(const PathVectorPtr_t &path);
 
+  // TODO remove when
+  // https://github.com/humanoid-path-planner/hpp-core/pull/305
+  // is released.
+  TimeParameterizationPtr_t lastTimeParameterization_;
+
  protected:
   using PathOptimizer::PathOptimizer;
 };  // class TOPPRA

--- a/tests/test-ill-formed-paths.cc
+++ b/tests/test-ill-formed-paths.cc
@@ -1,0 +1,33 @@
+#include"tests.hh"
+
+#include<hpp/core/straight-path.hh>
+
+TEST_CASE("Path of length 0") {
+  hp::DevicePtr_t device = makeDevice();
+  auto problem = hc::Problem::create(device);
+
+  auto addPathBefore = GENERATE(false, true);
+  auto addPathAfter = GENERATE(false, true);
+
+  CAPTURE(addPathBefore, addPathAfter);
+
+  hc::PathVectorPtr_t pv = hc::PathVector::create(device->configSize(), device->numberDof());
+  hp::vector_t q1 (device->configSize()),
+               q2 (device->configSize()),
+               q3 (device->configSize());
+  q1 << 0.;
+  q2 << 1.;
+  q3 << 2.;
+  if (addPathBefore)
+    pv->appendPath(hc::StraightPath::create(device, q1, q2, 1.));
+  pv->appendPath(hc::StraightPath::create(device, q2, q2, 0.));
+  if (addPathAfter)
+    pv->appendPath(hc::StraightPath::create(device, q2, q3, 1.));
+
+  auto opt = hc::pathOptimization::TOPPRA::create(problem);
+  hc::PathVectorPtr_t res;
+  CHECK_NOTHROW(res = opt->optimize(pv));
+  if (!addPathBefore && !addPathAfter)
+    CHECK(res->length() == 0.);
+  INFO("length: " << res->length());
+}

--- a/tests/test-path-serialization.cc
+++ b/tests/test-path-serialization.cc
@@ -1,0 +1,56 @@
+#include <hpp/core/straight-path.hh>
+#include <hpp/manipulation/device.hh>
+#include <hpp/pinocchio/serialization.hh>
+#include <hpp/pinocchio/urdf/util.hh>
+
+#include "../src/serialization.hh"
+#include "tests.hh"
+
+TEST_CASE("serialize and read") {
+  std::string pathStringVersion;
+  {
+    hp::DevicePtr_t device = makeDevice();
+    auto problem = hc::Problem::create(device);
+
+    auto path = makeCubicSpline(problem);
+    std::ostringstream oss;
+    oss << *path;
+    pathStringVersion = oss.str();
+
+    std::ofstream fs("path.txt");
+    hpp::serialization::text_oarchive archive(fs);
+    archive.insert(device->name(), device.get());
+    archive << path;
+  }
+  INFO(pathStringVersion);
+  {
+    hp::DevicePtr_t device = makeDevice();
+
+    std::ifstream fs("path.txt");
+    hpp::serialization::text_iarchive archive(fs);
+    archive.insert(device->name(), device.get());
+    hc::PathVectorPtr_t path;
+    archive >> path;
+
+    std::ostringstream oss;
+    oss << *path;
+    std::string pathAfterSerialization = oss.str();
+    INFO(pathAfterSerialization);
+    CHECK(pathStringVersion == pathAfterSerialization);
+  }
+}
+
+/*
+TEST_CASE("inspect serialized path") {
+  hpp::manipulation::Device::create("fake_world");
+  hp::DevicePtr_t device = hp::Device::create("world");
+  hpp::pinocchio::urdf::loadModel(
+      device, 0, "", "anchor", "package://ur_description_eureka/urdf/ur3e.urdf",
+      "package://ur_description_eureka/srdf/ur3e.srdf");
+  hc::PathPtr_t path;
+
+  hc::parser::serializePath<hpp::serialization::binary_iarchive>(
+      device, path, "./last-hpp-toppra-path.bin");
+  std::cout << *path << std::endl;
+}
+*/

--- a/tests/test_read_path.py
+++ b/tests/test_read_path.py
@@ -1,0 +1,179 @@
+import toppra.cpp
+import toppra.interpolator
+import hpp_toppra_cpp
+import matplotlib.pyplot as plt
+import numpy as np
+import typing as T
+
+from eureka.config.device_config.robots import URRobotConfig
+
+robot_config = URRobotConfig(model="3e")
+vel_limits = robot_config.joint_velocity_limits[1, :]
+acc_limits = robot_config.joint_acceleration_limits[1, :]
+
+device = hpp_toppra_cpp.pinocchio.Device.create("world")
+hpp_toppra_cpp.pinocchio.urdf.loadModel(
+    device,
+    0,
+    "",
+    "anchor",
+    "package://ur_description_eureka/urdf/ur3e.urdf",
+    "package://ur_description_eureka/srdf/ur3e.srdf",
+)
+
+path = hpp_toppra_cpp.core.readBinPath(device, "../last-hpp-toppra-path.bin")
+print(path)
+
+times = [0]
+subpaths = []
+for i in range(path.numberPaths()):
+    subpath = path.pathAtRank(i)
+    subpaths.append(subpath)
+    times.append(times[-1] + subpath.timeRange[1])
+n = len(path.eval(0)[0])
+
+
+def draw_vertical_lines(times):
+    for t in times:
+        plt.axvline(t)
+
+
+def plot_path(path):
+    times = []
+    if isinstance(path, hpp_toppra_cpp.core.PathVector):
+        times.append(0)
+        for i in range(path.numberPaths()):
+            subpath = path.pathAtRank(i)
+            times.append(times[-1] + subpath.timeRange[1])
+
+    ts = np.linspace(path.timeRange[0], path.timeRange[1], num=10000)
+    plt.subplot(3, 1, 1)
+    lines = plt.plot(ts, [path.eval(t)[0] for t in ts])
+    for i, l in enumerate(lines):
+        l.set_label(f"q{i}")
+    draw_vertical_lines(times)
+    plt.legend()
+    plt.subplot(3, 1, 2)
+    lines = plt.plot(ts, [path.derivative(t, 1) for t in ts])
+    for i, l in enumerate(lines):
+        l.set_label(f"v{i}")
+    draw_vertical_lines(times)
+    plt.legend()
+    plt.subplot(3, 1, 3)
+    lines = plt.plot(ts, [path.derivative(t, 2) for t in ts], "+")
+    for i, l in enumerate(lines):
+        l.set_label(f"a{i}")
+    draw_vertical_lines(times)
+    plt.legend()
+
+
+# Assuming constant acceleration, calculate spline coefficient
+# s_i(t) = a[i] + b[i] (t - t0[i]) + c[i] (t - t0[i])**2
+class ConstAccel:
+    def __init__(self, t, s, sd, path: toppra.cpp.GeometricPath):
+        sd2 = sd**2
+        ds = s[1:] - s[:-1]
+        self._t0 = t[:-1]
+        self._T = t[-1]
+        self._c = (sd2[1:] - sd2[:-1]) / ds / 4
+        self._b = sd[:-1]
+        self._a = s[:-1]
+        self._q = path
+
+    def s(self, t, order=0):
+        for i, t0 in enumerate(self._t0):
+            if t < t0:
+                if i > 0:
+                    i = i - 1
+                break
+        dt = t - self._t0[i]
+        if order == 0:
+            return self._a[i] + self._b[i] * dt + self._c[i] * dt**2
+        elif order == 1:
+            return self._b[i] + 2 * self._c[i] * dt
+        elif order == 2:
+            return 2 * self._c[i]
+        else:
+            return 0.0
+
+    def q(self, t, order=0):
+        assert order in [0, 1, 2]
+        s = self.s(t, order=0)
+        q = self._q.eval_single(s, order=0)
+        if order == 0:
+            return q
+        sd = self.s(t, order=1)
+        qs = self._q.eval_single(s, order=1)
+        if order == 1:
+            return qs * sd
+        sdd = self.s(t, order=2)
+        qss = self._q.eval_single(s, order=2)
+        if order == 2:
+            return qs * sdd + qss * sd**2
+
+    def eval(self, t):
+        return self.q(t, order=0), True
+
+    def derivative(self, t, order):
+        return self.q(t, order=order)
+
+    @property
+    def timeRange(self):
+        return 0, self._T
+
+
+def run_toppra(
+    path: hpp_toppra_cpp.core.Path,
+    vel_limits: T.Optional[np.ndarray] = None,
+    acc_limits: T.Optional[np.ndarray] = None,
+    N: int = 200,
+):
+    path_wrapper = hpp_toppra_cpp.core.TOPPRAPathWrapper(path)
+    constraints = []
+    if vel_limits is not None:
+        vel = toppra.cpp.LinearJointVelocity(-vel_limits, vel_limits)
+        vel.discretizationType = toppra.cpp.Interpolation
+        constraints.append(vel)
+    if acc_limits is not None:
+        acc = toppra.cpp.LinearJointAcceleration(-acc_limits, acc_limits)
+        acc.discretizationType = toppra.cpp.Interpolation
+        constraints.append(acc)
+
+    algo = toppra.cpp.TOPPRA(constraints, path_wrapper)
+    gridpointsMethod = 2
+    if gridpointsMethod == 0:
+        algo.setGridpoints(toppra.interpolator.propose_gridpoints(path_wrapper,
+            min_nb_points=N))
+    elif gridpointsMethod == 1:
+        algo.setGridpoints(path_wrapper.proposeGridpoints(minNbPoints=N))
+    elif gridpointsMethod == 2:
+        initialGridpoints = [0.]
+        for i in range(path.numberPaths()):
+            initialGridpoints.append(initialGridpoints[-1] + path.pathAtRank(i).length())
+        algo.setGridpoints(path_wrapper.proposeGridpoints(minNbPoints=N, initialGridpoints=initialGridpoints))
+    else:
+        algo.setN(N)
+    algo.computePathParametrization()
+
+    # Reconstruct s, sd and sdd
+    s = algo.parametrizationData.gridpoints
+    ds = s[1:] - s[:-1]
+    sd2 = algo.parametrizationData.parametrization
+    sd = np.sqrt(sd2)
+    sdd = (sd2[1:] - sd2[:-1]) / 2 / ds
+
+    # Calculate t
+    dt = ds / (sd[1:] + sd[:-1]) * 2
+    t = np.insert(np.cumsum(dt), 0, 0.0)
+
+    S = ConstAccel(t, s, sd, path_wrapper)
+
+    return S, (t, s, sd, sdd)
+
+
+# plot_path(path)
+# plt.show()
+
+S, rets = run_toppra(path, vel_limits, acc_limits, N=1000)
+plot_path(S)
+plt.show()

--- a/tests/test_toppra.py
+++ b/tests/test_toppra.py
@@ -1,0 +1,156 @@
+import toppra.cpp
+import numpy as np
+import matplotlib.pyplot as plt
+
+# P(t) = sum_i=0..5( c_i t^i )
+# P(0) = 0 = c_0
+# P'(0) = 0 = c_1
+# P''(0) = 0 = c_2
+
+# P(1) = 1 = c_3 + c_4 + c_5
+# P'(1) = 0 = 3 c_3 + 4 c_4 + 5 c_5
+# P''(1) = 0 = 6 c_3 + 12 c_4 + 20 c_5
+# c_3 = 10
+# c_4 = -15
+# c_5 = 6
+
+K = np.zeros((6, 6))
+t_order_conditions = [ (0,0) for _ in range(6) ]
+boundary_conditions = np.zeros(6)
+
+
+def set_boundary_condition(row, order, s, value):
+    """Set the row-th boundary condition:
+
+    d^order P / ds^order (s) = value
+    """
+    assert order in [0, 1, 2]
+    if order == 0:
+        C = [
+            1,
+        ] * 6
+    if order == 1:
+        C = [0, 1, 2, 3, 4, 5]
+    if order == 2:
+        C = [0, 0, 2, 6, 12, 20]
+
+    d = K.shape[1] - 1
+    for j in range(order):
+        K[row, d - j] = 0
+    K[row, d - order] = 1
+    for j in range(order + 1, K.shape[1]):
+        K[row, d - j] = s * K[row, d - j + 1]
+
+    K[row] *= list(reversed(C))
+    t_order_conditions[row] = (s, order)
+    boundary_conditions[row] = value
+
+
+set_boundary_condition(0, 0, 0.0, 0.0)  # P(0) = 0
+set_boundary_condition(1, 0, 1.0, 1.0)  # P(1) = 1
+set_boundary_condition(2, 1, 0.0, 0.0)  # P'(0) = 0
+set_boundary_condition(3, 1, 1.0, 0.0)  # P'(1) = 0
+set_boundary_condition(4, 2, 0., 0.0)  # P''(0) = 0
+# set_boundary_condition(4, 1, 0.5, 0.0)  # P'(0.5) = 0
+set_boundary_condition(5, 2, 1.0, 0.0)  # P''(1) = 0
+
+spline_coeffs = np.linalg.solve(K, boundary_conditions)
+
+path = toppra.cpp.PiecewisePolyPath([spline_coeffs.tolist()], [0, 1])
+for (t, order), value in zip(t_order_conditions, boundary_conditions):
+    np.testing.assert_allclose(path.eval_single(t, order), value, atol=1e-8)
+
+vel = toppra.cpp.LinearJointVelocity([-1], [1])
+vel.discretizationType = toppra.cpp.Interpolation
+acc = toppra.cpp.LinearJointAcceleration([-2], [2])
+acc.discretizationType = toppra.cpp.Interpolation
+
+algo = toppra.cpp.TOPPRA([vel, acc], path)
+algo.setN(200)
+algo.computePathParametrization()
+
+# Reconstruct s, sd and sdd
+s = algo.parametrizationData.gridpoints
+ds = s[1:] - s[:-1]
+sd2 = algo.parametrizationData.parametrization
+sd = np.sqrt(sd2)
+sdd = (sd2[1:] - sd2[:-1]) / 2 / ds
+
+# Calculate t
+dt = ds / (sd[1:] + sd[:-1]) * 2
+t = np.insert(np.cumsum(dt), 0, 0.0)
+
+# Assuming constant acceleration, calculate spline coefficient
+# s_i(t) = a[i] + b[i] (t - t0[i]) + c[i] (t - t0[i])**2
+class ConstAccel:
+    def __init__(self, t, s, sd, path):
+        sd2 = sd**2
+        ds = s[1:] - s[:-1]
+        self._t0 = t[:-1]
+        self._c = (sd2[1:] - sd2[:-1]) / ds / 4
+        self._b = sd[:-1]
+        self._a = s[:-1]
+        self._q = path
+
+    def s(self, t, order=0):
+        for i, t0 in enumerate(self._t0):
+            if t < t0:
+                if i > 0:
+                    i = i - 1
+                break
+        dt = t - self._t0[i]
+        if order == 0:
+            return self._a[i] + self._b[i] * dt + self._c[i] * dt**2
+        elif order == 1:
+            return self._b[i] + 2 * self._c[i] * dt
+        elif order == 2:
+            return 2 * self._c[i]
+        else:
+            return 0.0
+
+    def q(self, t, order=0):
+        assert order in [0, 1, 2]
+        s = self.s(t, order=0)
+        q = path.eval_single(s, order=0)
+        if order == 0:
+            return q
+        sd = self.s(t, order=1)
+        qs = path.eval_single(s, order=1)
+        if order == 1:
+            return qs * sd
+        sdd = self.s(t, order=2)
+        qss = path.eval_single(s, order=2)
+        if order == 2:
+            return qs * sdd + qss * sd**2
+
+ss = np.linspace(0, 1, num=1000)
+q = [path.eval_single(u, order=0) for u in ss]
+v = [path.eval_single(u, order=1) for u in ss]
+a = [path.eval_single(u, order=2) for u in ss]
+plt.figure()
+plt.title("Initial trajectory")
+plt.plot(ss, q, label="q")
+plt.plot(ss, v, label="v")
+plt.plot(ss, a, label="a")
+plt.legend()
+
+S = ConstAccel(t, s, sd, path)
+
+ts = np.linspace(0, t[-1], num=10000)
+q = [S.q(u, order=0) for u in ts]
+v = [S.q(u, order=1) for u in ts]
+a = [S.q(u, order=2) for u in ts]
+plt.figure()
+plt.title("Timed trajectory")
+plt.plot(ts, q, label="q")
+plt.plot(ts, v, label="v")
+plt.plot(ts, a, label="a")
+plt.legend()
+
+plt.figure()
+plt.title("Time parametrization")
+#plt.plot(ts, [ S.s(u, order=0) for u in ts ], label="s")
+plt.plot(ts, [ S.s(u, order=1) for u in ts ], label="sd")
+#plt.plot(ts, [ S.s(u, order=2) for u in ts ], label="sdd")
+plt.legend()
+plt.show()

--- a/tests/tests.cc
+++ b/tests/tests.cc
@@ -1,0 +1,204 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
+#include<iostream>
+#include<pinocchio/multibody/model.hpp>
+#include<hpp/pinocchio/urdf/util.hh>
+
+#include<hpp/core/problem.hh>
+#include<hpp/core/path-vector.hh>
+#include<hpp/core/path/spline.hh>
+#include<hpp/core/steering-method/spline.hh>
+
+#include"../src/toppra.hh"
+
+namespace hc = hpp::core;
+namespace hp = hpp::pinocchio;
+
+typedef hc::steeringMethod::Spline< hc::path::BernsteinBasis, 1 > SteerSplineOrder1;
+typedef hc::steeringMethod::Spline< hc::path::BernsteinBasis, 3 > SteerSplineOrder3;
+typedef hc::steeringMethod::Spline< hc::path::BernsteinBasis, 5 > SteerSplineOrder5;
+
+void print_path_evaluation(hc::PathPtr_t p, int N) {
+  hp::vector_t q (p->outputSize()), v(p->outputDerivativeSize()), a(p->outputDerivativeSize());
+  hp::value_type
+    t = 0.0,
+    t0 = p->timeRange().first,
+    t1 = p->timeRange().second;
+  std::cout
+    << "Time interval: " << t0 << ", " << t1
+    << "\nt, q, v, a\n";
+  for (int i = 0; i <= N; ++i) {
+    t = t0 + hp::value_type(i) / N * (t1 - t0);
+    p->eval(q, t);
+    p->derivative(v, t, 1);
+    p->derivative(a, t, 2);
+    std::cout << t << ", " << q << ", " << v << ", " << a << '\n';
+  }
+}
+
+void check_path_velocity(hc::PathPtr_t p) {
+  hp::vector_t v(p->outputDerivativeSize());
+  hp::value_type
+    t = 0.0,
+    t0 = p->timeRange().first,
+    t1 = p->timeRange().second;
+  int N = 1000;
+  for (int i = 0; i <= N; ++i) {
+    t = t0 + hp::value_type(i) / N * (t1 - t0);
+    p->derivative(v, t, 1);
+    if (std::abs(v[0]) < 0.01) {
+      WARN("small velocity at " << t << ", " << v);
+    }
+  }
+}
+
+static const hc::value_type velLimit = 1.;
+static const hc::value_type accLimit = 2.;
+static const hc::value_type constraintRelativeTol = 1.02;
+
+hp::DevicePtr_t makeDevice() {
+  hp::DevicePtr_t device = hp::Device::create("test");
+  hp::urdf::loadModelFromString(device, 0, "", "prismatic_x",
+      "<robot name='n'><link name='base_link'/></robot>", "");
+
+  device->model().velocityLimit << velLimit;
+
+  return device;
+}
+
+hc::PathVectorPtr_t makeCubicSpline(hc::ProblemPtr_t p) {
+  auto sm = SteerSplineOrder3::create(p);
+  hp::vector_t q1(p->robot()->neutralConfiguration()), q2(q1);
+  hp::matrix_t d1(p->robot()->numberDof(), 1),
+               d2(p->robot()->numberDof(), 1);
+  std::vector<int> orders {1};
+
+  q1 << 0.0;
+  q2 << 1.0;
+  d1 << 0.1;
+  d2 << 0.1;
+
+  auto spline = sm->steer(q1, orders, d1, q2, orders, d2);
+  auto inputPath = hc::PathVector::create(p->robot()->configSize(), p->robot()->numberDof());
+  inputPath->appendPath(spline);
+  return inputPath;
+}
+
+hc::PathVectorPtr_t makeQuinticSpline(hc::ProblemPtr_t p, hc::value_type v0, hc::value_type v1) {
+  auto sm = SteerSplineOrder5::create(p);
+  hp::vector_t q1(p->robot()->neutralConfiguration()), q2(q1);
+  hp::matrix_t d1(p->robot()->numberDof(), 2),
+               d2(p->robot()->numberDof(), 2);
+  std::vector<int> orders {1, 2};
+
+  q1 << 0.0;
+  q2 << 1.0;
+  d1 << v0, 0.0;
+  d2 << v1, 0.0;
+
+  auto spline = sm->steer(q1, orders, d1, q2, orders, d2);
+  auto inputPath = hc::PathVector::create(p->robot()->configSize(), p->robot()->numberDof());
+  inputPath->appendPath(spline);
+  return inputPath;
+}
+
+TEST_CASE("Test parameters") {
+  hp::DevicePtr_t device = makeDevice();
+
+  auto problem = hc::Problem::create(device);
+  hc::PathVectorPtr_t spline = makeCubicSpline(problem);
+  auto opt = hc::pathOptimization::TOPPRA::create(problem);
+  hp::vector_t accLimits;
+
+  problem->setParameter("PathOptimization/TOPPRA/interpolationMethod", hc::Parameter(std::string("hermite")));
+  CHECK_NOTHROW(opt->optimize(spline));
+
+  problem->setParameter("PathOptimization/TOPPRA/N", hc::Parameter(hp::size_type(200)));
+  problem->setParameter("PathOptimization/TOPPRA/interpolationMethod", hc::Parameter(std::string("constant_acceleration")));
+  CHECK_NOTHROW(opt->optimize(spline));
+
+  accLimits.resize(2);
+  problem->setParameter("PathOptimization/TOPPRA/accelerationLimits", hc::Parameter(accLimits));
+  CHECK_THROWS(opt->optimize(spline));
+
+  accLimits.resize(1);
+  accLimits << accLimit;
+  problem->setParameter("PathOptimization/TOPPRA/accelerationLimits", hc::Parameter(accLimits));
+  CHECK_NOTHROW(opt->optimize(spline));
+
+  problem->setParameter("PathOptimization/TOPPRA/interpolationMethod", hc::Parameter(std::string("not_an_interpolation_method")));
+  CHECK_THROWS(opt->optimize(spline));
+}
+
+TEST_CASE("Run TOPPRA optimizer") {
+  hp::DevicePtr_t device = makeDevice();
+  auto problem = hc::Problem::create(device);
+
+  std::vector<hc::PathVectorPtr_t> paths {
+    makeCubicSpline(problem),
+    makeCubicSpline(problem),
+    makeQuinticSpline(problem, 0.2, 0.2),
+    makeQuinticSpline(problem, 0.0, 0.1),
+  };
+  std::vector<std::string> descs {
+    "cubic spline without acceleration limits",
+    "cubic spline with acceleration limits",
+    "quintic spline with non-zero velocity",
+    "quintic spline with zero velocity at start",
+  };
+  std::vector<hc::vector_t> accLimitValues {
+    hc::vector_t(), // No acceleration limits for cubic spline
+    (hc::vector_t(1) << accLimit).finished(),
+    (hc::vector_t(1) << accLimit).finished(),
+    (hc::vector_t(1) << accLimit).finished(),
+  };
+
+  auto iPath = GENERATE(0, 1, 2);
+  INFO(descs[iPath]);
+
+  hp::vector_t accLimits = accLimitValues[iPath];
+  CAPTURE(iPath, accLimits);
+  problem->setParameter("PathOptimization/TOPPRA/accelerationLimits", hc::Parameter(accLimits));
+  problem->setParameter("PathOptimization/TOPPRA/interpolationMethod", hc::Parameter(std::string("constant_acceleration")));
+  problem->setParameter("PathOptimization/TOPPRA/N", hc::Parameter(hp::size_type(500)));
+
+  auto inputPath = paths[iPath];
+  auto opt = hc::pathOptimization::TOPPRA::create(problem);
+  auto outputPath = opt->optimize(inputPath);
+
+  check_path_velocity(inputPath);
+
+  hp::vector_t q (device->configSize()), v(device->numberDof()), a(device->numberDof());
+  hp::value_type
+    t0 = outputPath->timeRange().first,
+    t1 = outputPath->timeRange().second;
+
+  // Check that initial and final velocities are zero
+  outputPath->derivative(v, t0, 1);
+  CHECK(v.isZero());
+  outputPath->derivative(v, t1, 1);
+  CHECK(v.isZero());
+  int N = 1000;
+  // TODO
+  // Path::timeParameterization is protected...
+  // see https://github.com/humanoid-path-planner/hpp-core/pull/305
+  // auto param = outputPath->timeParameterization();
+  auto param = opt->lastTimeParameterization_;
+  for (int i = 0; i <= N; ++i) {
+    hc::value_type t = t0 + hc::value_type(i) / N * (t1-t0);
+    hc::value_type
+      s = param->value(t),
+      sd = param->derivative(t, 1),
+      sdd = param->derivative(t, 2);
+    inputPath->derivative(v, s, 1);
+    inputPath->derivative(a, s, 2);
+    CAPTURE(t, s, sd, sdd, v, a);
+
+    outputPath->derivative(v, t, 1);
+    outputPath->derivative(a, t, 2);
+    CHECK(v[0] < velLimit * constraintRelativeTol);
+    if (accLimits.size() > 0)
+      CHECK(a[0] < accLimits[0]*constraintRelativeTol);
+  }
+}

--- a/tests/tests.hh
+++ b/tests/tests.hh
@@ -1,0 +1,20 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
+#include<hpp/core/problem.hh>
+#include<hpp/core/path-vector.hh>
+#include<hpp/core/path/spline.hh>
+#include<hpp/core/steering-method/spline.hh>
+
+#include"../src/toppra.hh"
+
+namespace hc = hpp::core;
+namespace hp = hpp::pinocchio;
+
+typedef hc::steeringMethod::Spline< hc::path::BernsteinBasis, 1 > SteerSplineOrder1;
+typedef hc::steeringMethod::Spline< hc::path::BernsteinBasis, 3 > SteerSplineOrder3;
+typedef hc::steeringMethod::Spline< hc::path::BernsteinBasis, 5 > SteerSplineOrder5;
+
+hp::DevicePtr_t makeDevice();
+
+hc::PathVectorPtr_t makeCubicSpline(hc::ProblemPtr_t p);


### PR DESCRIPTION
This PR improves the robustness of the time parametrization.

- add unit tests
- change discretisation type to `Interpolation` (related to https://github.com/hungpham2511/toppra/pull/225)
- add parameters:
  - `accelerationLimits` to give to the user the ability to set the acceleration limits
  - `interpolationMethod` to allow generating trajectories with constant acceleration, as TOPPRA uses internally.
  - `gridpointMethod` to allow sampling parameters following a uniform distribution in time space or parameter space. Choosing time space can help when the path has high jerk. 
  - `inputSerialization` to trigger the serialization of the input path. The serialized input path can then be inspected. One can check the example script in the test folder.

This PR also adds a Python script that calls TOPPRA independently of HPP. This has been useful for this PR and will probably be useful in the future.